### PR TITLE
RBE10 calculation adjustments

### DIFF
--- a/standalone/CMakeLists.txt
+++ b/standalone/CMakeLists.txt
@@ -32,4 +32,9 @@ include_directories(${PROJECT_SOURCE_DIR}/include)
 
 add_executable (${PROJECT_NAME} monas.cc ${SOURCES})
 
+# GSL libraries
+find_package(GSL REQUIRED)
+include_directories(${GSL_INCLUDE_DIRS})
+target_link_libraries(monas ${GSL_LIBRARIES} ${GSL_CBLAS_LIBRARIES})
+
 

--- a/standalone/include/TsGetSurvivalRBEQualityFactor.hh
+++ b/standalone/include/TsGetSurvivalRBEQualityFactor.hh
@@ -58,6 +58,8 @@ class TsGetSurvivalRBEQualityFactor
 		// TO DO: LQ/linear fit functions
 		vector<double> logTransform(const vector<double>& S);
 		void quadraticFit(const vector<double>& doses, const vector<double>& logS, double& alpha, double& beta, double& error);
+		// Quadratic fit with GSL library
+		void fit_quadratic_GSL(const std::vector<double>& doses, const std::vector<double>& logS, double& alpha, double& beta, double& error);
 		void linearFit(const vector<double>& doses, const vector<double>& logS, double& alpha, double& error);
 		double calculateDose(double alpha, double beta, double targetS);
 


### PR DESCRIPTION
I re-implemented the LQ fit with a function already provided in the GSL library. This must be installed and I also added three lines in the CMakeLists.txt to include and link the libraries (redo the cmake $path_to_monas_standalone). However, this was not the problem for the calculation of RBE10, the linear fit was overwriting the alpha on the LQ one. Now it works fine.